### PR TITLE
feat: bootstrap Spring Boot code dojo app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target/
+.idea/
+*.iml
+*.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# init
+# Code Dojo (MVP)
+
+Maven + Spring Boot 的代码练习网站骨架。内置题库目录结构（Java/Python/其它），提供：
+- 页面：主页、练习页（Monaco Editor）
+- API：GET /api/problems?lang=java ；POST /api/submit （占位，返回伪结果）
+- 题库示例：src/main/resources/problems/<lang>/*.json
+
+## 运行
+要求：JDK 17+，Maven 3.9+
+```bash
+mvn spring-boot:run
+# 浏览 http://localhost:8080
+```
+
+## 结构
+
+* templates/index.html：入口页
+* templates/practice.html：练习页（Monaco Editor）
+* static/js/app.js：前端逻辑
+* resources/problems：题库（JSON）
+* ProblemService：加载/缓存题库
+* ProblemController：题目与提交 API
+* TODO：接入 Judge0 或自建判题服务
+
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>code-dojo</artifactId>
+  <version>0.1.0</version>
+  <name>code-dojo</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <java.version>17</java.version>
+    <spring.boot.version>3.3.3</spring.boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <image>
+            <builder>paketobuildpacks/builder:base</builder>
+          </image>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/com/example/coddojo/CodeDojoApplication.java
+++ b/src/main/java/com/example/coddojo/CodeDojoApplication.java
@@ -1,0 +1,11 @@
+package com.example.coddojo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CodeDojoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CodeDojoApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/coddojo/controller/PageController.java
+++ b/src/main/java/com/example/coddojo/controller/PageController.java
@@ -1,0 +1,18 @@
+package com.example.coddojo.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class PageController {
+
+    @GetMapping("/")
+    public String index() {
+        return "index";
+    }
+
+    @GetMapping("/practice")
+    public String practice() {
+        return "practice";
+    }
+}

--- a/src/main/java/com/example/coddojo/controller/ProblemController.java
+++ b/src/main/java/com/example/coddojo/controller/ProblemController.java
@@ -1,0 +1,39 @@
+package com.example.coddojo.controller;
+
+import com.example.coddojo.model.Problem;
+import com.example.coddojo.model.SubmissionPayload;
+import com.example.coddojo.model.SubmissionResult;
+import com.example.coddojo.service.ProblemService;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class ProblemController {
+
+    private final ProblemService problemService;
+
+    public ProblemController(ProblemService problemService) {
+        this.problemService = problemService;
+    }
+
+    @GetMapping(value = "/problems", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<Problem> list(@RequestParam(defaultValue = "java") String lang) {
+        return problemService.loadProblems(lang);
+    }
+
+    @PostMapping(value = "/submit", consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public SubmissionResult submit(@Valid @RequestBody SubmissionPayload payload) {
+        // TODO: 调用 Judge0 或自建判题服务
+        // 这里先返回“伪通过”结果，便于前端联调
+        SubmissionResult res = new SubmissionResult();
+        res.setProblemId(payload.getProblemId());
+        res.setPassed(true);
+        res.setMessage("Stub: 判题未接入，默认通过。稍后对接 Judge0。");
+        return res;
+    }
+}

--- a/src/main/java/com/example/coddojo/model/Problem.java
+++ b/src/main/java/com/example/coddojo/model/Problem.java
@@ -1,0 +1,26 @@
+package com.example.coddojo.model;
+
+import java.util.List;
+
+public class Problem {
+    private String id;
+    private String title;
+    private String language; // java/python/...
+    private String starterCode;
+    private String description;
+    private List<TestCase> tests;
+
+    // getters/setters
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+    public String getStarterCode() { return starterCode; }
+    public void setStarterCode(String starterCode) { this.starterCode = starterCode; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public List<TestCase> getTests() { return tests; }
+    public void setTests(List<TestCase> tests) { this.tests = tests; }
+}

--- a/src/main/java/com/example/coddojo/model/SubmissionPayload.java
+++ b/src/main/java/com/example/coddojo/model/SubmissionPayload.java
@@ -1,0 +1,20 @@
+package com.example.coddojo.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SubmissionPayload {
+    @NotBlank
+    private String problemId;
+    @NotBlank
+    private String language;
+    @NotBlank
+    private String sourceCode;
+
+    // getters/setters
+    public String getProblemId() { return problemId; }
+    public void setProblemId(String problemId) { this.problemId = problemId; }
+    public String getLanguage() { return language; }
+    public void setLanguage(String language) { this.language = language; }
+    public String getSourceCode() { return sourceCode; }
+    public void setSourceCode(String sourceCode) { this.sourceCode = sourceCode; }
+}

--- a/src/main/java/com/example/coddojo/model/SubmissionResult.java
+++ b/src/main/java/com/example/coddojo/model/SubmissionResult.java
@@ -1,0 +1,15 @@
+package com.example.coddojo.model;
+
+public class SubmissionResult {
+    private String problemId;
+    private boolean passed;
+    private String message;
+
+    // getters/setters
+    public String getProblemId() { return problemId; }
+    public void setProblemId(String problemId) { this.problemId = problemId; }
+    public boolean isPassed() { return passed; }
+    public void setPassed(boolean passed) { this.passed = passed; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/example/coddojo/model/TestCase.java
+++ b/src/main/java/com/example/coddojo/model/TestCase.java
@@ -1,0 +1,12 @@
+package com.example.coddojo.model;
+
+public class TestCase {
+    private String input;
+    private String expected;
+
+    // getters/setters
+    public String getInput() { return input; }
+    public void setInput(String input) { this.input = input; }
+    public String getExpected() { return expected; }
+    public void setExpected(String expected) { this.expected = expected; }
+}

--- a/src/main/java/com/example/coddojo/service/ProblemService.java
+++ b/src/main/java/com/example/coddojo/service/ProblemService.java
@@ -1,0 +1,41 @@
+package com.example.coddojo.service;
+
+import com.example.coddojo.model.Problem;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Service
+public class ProblemService {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Map<String, List<Problem>> cache = new HashMap<>();
+
+    public List<Problem> loadProblems(String lang) {
+        return cache.computeIfAbsent(lang.toLowerCase(Locale.ROOT), this::loadFromResources);
+    }
+
+    private List<Problem> loadFromResources(String lang) {
+        try {
+            PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+            Resource[] files = resolver.getResources("classpath:problems/" + lang + "/*.json");
+            List<Problem> list = new ArrayList<>();
+            for (Resource r : files) {
+                try (InputStream in = r.getInputStream()) {
+                    String json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                    Problem p = mapper.readValue(json, new TypeReference<Problem>(){});
+                    list.add(p);
+                }
+            }
+            return list;
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+server:
+  port: 8080
+spring:
+  thymeleaf:
+    cache: false
+  mvc:
+    static-path-pattern: /static/**
+# TODO: 判题服务配置占位
+judge0:
+  enabled: false
+  endpoint: https://example.com/judge0
+  token: ${JUDGE0_TOKEN:}

--- a/src/main/resources/problems/java/intro_hello.json
+++ b/src/main/resources/problems/java/intro_hello.json
@@ -1,0 +1,11 @@
+{
+  "id": "java_intro_hello",
+  "title": "打印问候（Java）",
+  "language": "java",
+  "description": "编写一个方法 `hello(String name)` 返回字符串 `Hello, <name>!`。",
+  "starterCode": "public class Solution {\n    public static String hello(String name) {\n        // TODO: 返回 \"Hello, <name>!\"\n        return \"\";\n    }\n}",
+  "tests": [
+    { "input": "Alice", "expected": "Hello, Alice!" },
+    { "input": "Bob",   "expected": "Hello, Bob!" }
+  ]
+}

--- a/src/main/resources/problems/misc/intro_string.json
+++ b/src/main/resources/problems/misc/intro_string.json
@@ -1,0 +1,10 @@
+{
+  "id": "misc_intro_string",
+  "title": "字符串拼接（其他）",
+  "language": "misc",
+  "description": "占位题：不同语言下都需要实现字符串拼接；此处仅演示。",
+  "starterCode": "// 这里可以放伪代码或目标语言模板",
+  "tests": [
+    { "input": "Alice", "expected": "Hello, Alice!" }
+  ]
+}

--- a/src/main/resources/problems/python/intro_hello.json
+++ b/src/main/resources/problems/python/intro_hello.json
@@ -1,0 +1,11 @@
+{
+  "id": "py_intro_hello",
+  "title": "打印问候（Python）",
+  "language": "python",
+  "description": "实现函数 hello(name): 返回字符串 'Hello, <name>!'。",
+  "starterCode": "def hello(name):\n    # TODO: 返回 \"Hello, <name>!\"\n    return \"\"",
+  "tests": [
+    { "input": "Alice", "expected": "Hello, Alice!" },
+    { "input": "Bob",   "expected": "Hello, Bob!" }
+  ]
+}

--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -1,0 +1,5 @@
+body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans CJK SC", Arial, sans-serif; margin:0; }
+header { padding: 12px 16px; border-bottom: 1px solid #eee; display:flex; gap:16px; align-items:center; }
+main { padding: 16px; max-width: 960px; margin: 0 auto; }
+button { padding: 8px 12px; cursor: pointer; }
+pre { background: #f8f8f8; padding: 8px; border: 1px solid #eee; }

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -1,0 +1,50 @@
+let currentProblems = [];
+let current = null;
+
+async function loadProblems(lang) {
+  const res = await fetch(`/api/problems?lang=${encodeURIComponent(lang)}`);
+  currentProblems = await res.json();
+  // 简化：取第一题
+  current = currentProblems[0];
+  const title = document.getElementById('problemTitle');
+  const desc = document.getElementById('problemDesc');
+  if (current) {
+    title.textContent = `${current.title} (${current.language})`;
+    desc.textContent = current.description || "";
+    if (window.editor) {
+      window.editor.setValue(current.starterCode || "");
+      // 切换高亮
+      const map = { java: "java", python: "python", misc: "javascript" };
+      const langName = map[current.language] || "javascript";
+      monaco.editor.setModelLanguage(window.editor.getModel(), langName);
+    }
+  } else {
+    title.textContent = "没有题目";
+    desc.textContent = "";
+  }
+}
+
+async function submitSolution() {
+  if (!current) return;
+  const payload = {
+    problemId: current.id,
+    language: current.language,
+    sourceCode: window.editor ? window.editor.getValue() : ""
+  };
+  const res = await fetch('/api/submit', {
+    method: 'POST',
+    headers: { 'Content-Type':'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const data = await res.json();
+  document.getElementById('resultBox').textContent =
+    `通过: ${data.passed}\n消息: ${data.message}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('loadProblems').addEventListener('click', () => {
+    const lang = document.getElementById('lang').value;
+    loadProblems(lang);
+  });
+  document.getElementById('submitBtn').addEventListener('click', submitSolution);
+});

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Code Dojo</title>
+  <link rel="stylesheet" href="/css/app.css"/>
+</head>
+<body>
+<header>
+  <h1>Code Dojo</h1>
+  <nav>
+    <a href="/practice">进入练习</a>
+  </nav>
+</header>
+<main>
+  <p>欢迎来到 Code Dojo。选择语言与题目，开始练习你的常用代码块。</p>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/practice.html
+++ b/src/main/resources/templates/practice.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8"/>
+  <title>练习 - Code Dojo</title>
+  <link rel="stylesheet" href="/css/app.css"/>
+  <!-- Monaco Editor (CDN) -->
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.51.0/min/vs/loader.js"></script>
+</head>
+<body>
+<header>
+  <h1>练习</h1>
+  <a href="/">返回首页</a>
+</header>
+
+<main>
+  <section>
+    <label>语言：
+      <select id="lang">
+        <option value="java">Java</option>
+        <option value="python">Python</option>
+        <option value="misc">Other</option>
+      </select>
+    </label>
+    <button id="loadProblems">加载题目</button>
+  </section>
+
+  <section>
+    <h2 id="problemTitle">选择语言后加载题目</h2>
+    <pre id="problemDesc"></pre>
+  </section>
+
+  <div id="editor" style="height: 360px; border:1px solid #ddd;"></div>
+  <button id="submitBtn">提交（占位）</button>
+  <pre id="resultBox"></pre>
+</main>
+
+<script src="/js/app.js"></script>
+<script>
+  // Monaco bootstrap
+  require.config({ paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.51.0/min/vs' }});
+  window.MonacoEnvironment = { getWorkerUrl: function () {
+      return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+        self.MonacoEnvironment = { baseUrl: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.51.0/min/' };
+        importScripts('https://cdn.jsdelivr.net/npm/monaco-editor@0.51.0/min/vs/base/worker/workerMain.js');
+      `)}`;
+    } };
+  require(["vs/editor/editor.main"], function () {
+    window.editor = monaco.editor.create(document.getElementById('editor'), {
+      value: "// 请选择语言并加载题目…",
+      language: "java",
+      automaticLayout: true
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Spring Boot web and API skeleton with page and problem controllers
- implement a problem service backed by JSON resource files
- provide Thymeleaf templates, static assets, and sample problem definitions

## Testing
- mvn -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68d8e50296a083289725d24a51de630e